### PR TITLE
Add CodeQL status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Lint Filenames action
 
 <p align="center">
-  <a href="https://github.com/batista/lint-filenames/actions"><img alt="typescript-action status" src="https://github.com/batista/lint-filenames/workflows/build-test/badge.svg"></a>
+  <a href="https://github.com/batista/lint-filenames/actions?query=workflow%3Abuild-test"><img alt="build-test action status" src="https://github.com/batista/lint-filenames/workflows/build-test/badge.svg"></a>
+  <a href="https://github.com/batista/lint-filenames/actions?query=workflow%3ACodeQL"><img alt="code-ql status" src="https://github.com/batista/lint-filenames/workflows/CodeQL/badge.svg"></a>
   <a href="https://github.com/batista/lint-filenames/blob/main/LICENSE"><img alt="license MIT" src="https://img.shields.io/github/license/batista/lint-filenames"></a>
 </p>
 


### PR DESCRIPTION
Adds the CodeQL status badge to README, and updates links the status buttons to go directly into the specified action.