### PR TITLE
ci: removes CodeQL Analysis on push to master

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
   schedule:


### PR DESCRIPTION
# Description
Based on the feedback from this broken [build](https://github.com/batista/lint-filenames/actions/runs/1654160950) 

# References
- https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#scanning-on-push