### PR TITLE
ci: build-test on master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: # rebuild any PRs and main branch changes
   pull_request:
   push:
     branches:
-      - main
+      - 'master'
       - 'releases/*'
 
 jobs:


### PR DESCRIPTION
# Description
The build was not being run on push to `master` as it expected a `main` branch instead.. 😅 