### PR TITLE
ci: dependabot-fixes-security-scanning

### DIFF
--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -29,8 +29,11 @@ jobs:
   codacy-security-scan:
     name: Codacy Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+
     steps:
-      # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
         uses: actions/checkout@v2
 

--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -15,6 +15,9 @@ name: Codacy Security Scan
 
 on:
   push:
+    # Dependabot triggered push events have read-only access, but uploading code
+    # scanning requires write access.
+    branches-ignore: [dependabot/**]
     branches: [ master ]
   pull_request:
     # The branches below must be a subset of the branches above

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,11 @@
 name: "CodeQL"
 
 on:
+  push:
+    # Dependabot triggered push events have read-only access, but uploading code
+    # scanning requires write access.
+    branches-ignore: [dependabot/**]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,9 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Description
Dependabot updates were triggering fails in builds on merge, this should prevent that from happening in the future