### PR TITLE
ci: revert the disable security analysis for dependabot

### DIFF
--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -15,9 +15,6 @@ name: Codacy Security Scan
 
 on:
   push:
-    # Dependabot triggered push events have read-only access, but uploading code
-    # scanning requires write access.
-    branches-ignore: [dependabot/**]
     branches: [ master ]
   pull_request:
     # The branches below must be a subset of the branches above

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,8 @@
 name: "CodeQL"
 
 on:
+  push:
+    branches: [ master ]
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,11 +1,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    # Dependabot triggered push events have read-only access, but uploading code
-    # scanning requires write access.
-    branches-ignore: [dependabot/**]
-    branches: [ master ]
   pull_request:
     branches: [ master ]
   schedule:


### PR DESCRIPTION
# Description
We want to verify if the new permission settings actually work. Also there can only exist one of these two statements `branches` or `branches-ignore` per context. 